### PR TITLE
Allow anchors with the target attribute to handle themselves correctly

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -25,6 +25,13 @@ bind = (el, binding, vnode) ->
 
 # Check an anchor tag
 export handleAnchor = (anchor, router) ->
+
+	console.log 'anchor', anchor
+
+	# If an explicit target attribute is set, then
+	# don't massage the anchor tag
+	return if anchor.getAttribute 'target'
+
 	if url = anchor.getAttribute 'href'
 		if isInternal url
 		then handleInternal anchor, url, router

--- a/index.coffee
+++ b/index.coffee
@@ -26,10 +26,8 @@ bind = (el, binding, vnode) ->
 # Check an anchor tag
 export handleAnchor = (anchor, router) ->
 
-	console.log 'anchor', anchor
-
-	# If an explicit target attribute is set, then
-	# don't massage the anchor tag
+	# If an explicit target attribute is set, then abort.  Assuming the author
+	# of the content knew what they were doing.
 	return if anchor.getAttribute 'target'
 
 	if url = anchor.getAttribute 'href'

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ bind = function bind(el, binding, vnode) {
 // Check an anchor tag
 var handleAnchor = exports.handleAnchor = function handleAnchor(anchor, router) {
   var url;
-  console.log('anchor', anchor);
   // If an explicit target attribute is set, then
   // don't massage the anchor tag
   if (anchor.getAttribute('target')) {

--- a/index.js
+++ b/index.js
@@ -65,6 +65,12 @@ bind = function bind(el, binding, vnode) {
 // Check an anchor tag
 var handleAnchor = exports.handleAnchor = function handleAnchor(anchor, router) {
   var url;
+  console.log('anchor', anchor);
+  // If an explicit target attribute is set, then
+  // don't massage the anchor tag
+  if (anchor.getAttribute('target')) {
+    return;
+  }
   if (url = anchor.getAttribute('href')) {
     if (isInternal(url)) {
       return handleInternal(anchor, url, router);


### PR DESCRIPTION
- if redactor wants to render target=“_blank”, then let it
- tested this locally