### PR TITLE
Revert "Bump url-parse from 1.4.0 to 1.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "coffeescript": "^2.2.4"
   },
   "dependencies": {
-    "url-parse": "1.5.0"
+    "url-parse": "1.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,7 +635,7 @@ private@^0.1.6, private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
-querystringify@^2.1.1:
+querystringify@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
@@ -720,10 +720,10 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-url-parse@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.0.tgz#90aba6c902aeb2d80eac17b91131c27665d5d828"
-  integrity sha512-9iT6N4s93SMfzunOyDPe4vo4nLcSu1yq0IQK1gURmjm8tQNlM6loiuCRrKG1hHGXfB2EWd6H4cGi7tGdaygMFw==
+url-parse@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.0.tgz#6bfdaad60098c7fe06f623e42b22de62de0d3d75"
+  integrity sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==
   dependencies:
-    querystringify "^2.1.1"
+    querystringify "^2.0.0"
     requires-port "^1.0.0"


### PR DESCRIPTION
Reverts BKWLD/vue-routing-anchor-parser#16 in response to https://github.com/BKWLD/vue-routing-anchor-parser/commit/3a538cb6c86defb9badb1eb3faf7839b783efbb7#commitcomment-53899938 (cc @jonjahr)