### PR TITLE
Add trailing slash to internal links option

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -96,6 +96,12 @@ export shouldOpenInNewWindow = (url) ->
 		return false if urlObj.href.match urlRegex
 	return true
 
+# add trailing slash 
+export addTrailingSlash = (to) -> 
+	url = new URL to
+	url.pathname += if url.pathname.endsWith "/" then "" else "/"
+	url.toString()
+
 # Directive definition with settings method for overriding the default settings.
 # I'm relying on Browser garbage collection to cleanup listeners.
 export default

--- a/index.coffee
+++ b/index.coffee
@@ -100,7 +100,7 @@ export shouldOpenInNewWindow = (url) ->
 # add trailing slash 
 export addTrailingSlash = (to) -> 
 	url = new URL to
-	url.pathname += if url.pathname.endsWith "/" then "" else "/"
+	url.pathname += if url.pathname.match(/\/$/) then "" else "/"
 	url.toString()
 
 # Directive definition with settings method for overriding the default settings.

--- a/index.coffee
+++ b/index.coffee
@@ -4,6 +4,7 @@ import URL from 'url-parse'
 # Default settings
 settings =
 	addBlankToExternal: false
+	addTrailingSlashToInternal: false
 	internalUrls: []
 	sameWindowUrls: []
 	internalHosts: []

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ var bind,
 // Default settings
 settings = {
   addBlankToExternal: false,
+  addTrailingSlashToInternal: false,
   internalUrls: [],
   sameWindowUrls: [],
   internalHosts: [],
@@ -183,6 +184,8 @@ var addTrailingSlash = exports.addTrailingSlash = function addTrailingSlash(to) 
 };
 
 exports.default = {
+  // if to.match /\/$/ then to else to + '/'
+
   // Directive definition with settings method for overriding the default settings.
   // I'm relying on Browser garbage collection to cleanup listeners.
   bind: bind,

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.shouldOpenInNewWindow = exports.makeRouterPath = exports.isInternal = exports.handleAnchor = undefined;
+exports.addTrailingSlash = exports.shouldOpenInNewWindow = exports.makeRouterPath = exports.isInternal = exports.handleAnchor = undefined;
 
 var _urlParse = require('url-parse');
 
@@ -172,6 +172,14 @@ var shouldOpenInNewWindow = exports.shouldOpenInNewWindow = function shouldOpenI
     }
   }
   return true;
+};
+
+// add trailing slash 
+var addTrailingSlash = exports.addTrailingSlash = function addTrailingSlash(to) {
+  var url;
+  url = new _urlParse2.default(to);
+  url.pathname += url.pathname.endsWith("/") ? "" : "/";
+  return url.toString();
 };
 
 exports.default = {

--- a/index.js
+++ b/index.js
@@ -179,13 +179,11 @@ var shouldOpenInNewWindow = exports.shouldOpenInNewWindow = function shouldOpenI
 var addTrailingSlash = exports.addTrailingSlash = function addTrailingSlash(to) {
   var url;
   url = new _urlParse2.default(to);
-  url.pathname += url.pathname.endsWith("/") ? "" : "/";
+  url.pathname += url.pathname.match(/\/$/) ? "" : "/";
   return url.toString();
 };
 
 exports.default = {
-  // if to.match /\/$/ then to else to + '/'
-
   // Directive definition with settings method for overriding the default settings.
   // I'm relying on Browser garbage collection to cleanup listeners.
   bind: bind,

--- a/nuxt/module.js
+++ b/nuxt/module.js
@@ -6,6 +6,7 @@ module.exports = function (options) {
 
 	// Accept options from module or config
 	options = {...options, ...this.options.anchorParser}
+	this.options.publicRuntimeConfig.anchorParser = options
 
 	// Register a plugin that applys the settings for SSR and non-SSR
 	this.addPlugin({

--- a/nuxt/module.js
+++ b/nuxt/module.js
@@ -6,6 +6,7 @@ module.exports = function (options) {
 
 	// Accept options from module or config
 	options = {...options, ...this.options.anchorParser}
+	// Expose module options to publicRuntimeConfig 
 	this.options.publicRuntimeConfig.anchorParser = options
 
 	// Register a plugin that applys the settings for SSR and non-SSR

--- a/smart-link.coffee
+++ b/smart-link.coffee
@@ -9,14 +9,14 @@ export default
 
 	props:
 		to: String # The URL gets passed here
-		internalTrailingSlash: Boolean # Optionally add trailing slash if is internal link
 
 	# Destructure the props and data we care about
 	render: (create, {
-		props: { to, internalTrailingSlash }
+		props: { to }
 		data
 		listeners
 		children
+		parent
 	}) ->
 		# If no "to", wrap children in a span so that children are nested
 		# consistently
@@ -30,7 +30,7 @@ export default
 			...data
 			nativeOn: listeners # nuxt-link doesn't forward events on it's own
 			props: 
-				to: if internalTrailingSlash 
+				to: if parent?.$config?.anchorParser?.addTrailingSlashToInternal 
 				then makeRouterPath addTrailingSlash to 
 				else makeRouterPath to
 		}, children

--- a/smart-link.coffee
+++ b/smart-link.coffee
@@ -1,22 +1,27 @@
 # Render a nuxt-link if an internal link or a v-parse-anchor wrapped a if not.
 # This is so that link pre-fetching works.
 
-import { isInternal, makeRouterPath, shouldOpenInNewWindow } from './index'
+import { isInternal, makeRouterPath, shouldOpenInNewWindow, addTrailingSlash } from './index'
 
 export default
 	name: 'SmartLink'
 	functional: true
 
-	# The URL gets passed here
-	props: to: String
+	props:
+		to: String # The URL gets passed here
+		internalTrailingSlash: Boolean # Optionally add trailing slash if is internal link
 
 	# Destructure the props and data we care about
 	render: (create, {
-		props: { to }
+		# props: { to, internalTrailingSlash }
+		props
 		data
 		listeners
 		children
 	}) ->
+		to = props.to
+		internalTrailingSlash = props.internalTrailingSlash
+		console.log 'rendering link, to is', to, 'internaltrailingslash is', internalTrailingSlash, 'props are', props
 
 		# If no "to", wrap children in a span so that children are nested
 		# consistently
@@ -29,7 +34,10 @@ export default
 		then create 'nuxt-link', {
 			...data
 			nativeOn: listeners # nuxt-link doesn't forward events on it's own
-			props: to: makeRouterPath to
+			props: 
+				to: if internalTrailingSlash 
+				then makeRouterPath addTrailingSlash to 
+				else makeRouterPath to
 		}, children
 
 		# Make a standard link that opens in a new window

--- a/smart-link.coffee
+++ b/smart-link.coffee
@@ -13,16 +13,11 @@ export default
 
 	# Destructure the props and data we care about
 	render: (create, {
-		# props: { to, internalTrailingSlash }
-		props
+		props: { to, internalTrailingSlash }
 		data
 		listeners
 		children
 	}) ->
-		to = props.to
-		internalTrailingSlash = props.internalTrailingSlash
-		console.log 'rendering link, to is', to, 'internaltrailingslash is', internalTrailingSlash, 'props are', props
-
 		# If no "to", wrap children in a span so that children are nested
 		# consistently
 		if !to then return create 'span', data, children

--- a/smart-link.js
+++ b/smart-link.js
@@ -23,19 +23,18 @@ exports.default = {
   name: 'SmartLink',
   functional: true,
   props: {
-    to: String, // The URL gets passed here
-    internalTrailingSlash: Boolean // Optionally add trailing slash if is internal link
+    to: String // The URL gets passed here
   },
 
   // Destructure the props and data we care about
   render: function render(create, _ref) {
-    var _ref$props = _ref.props,
-        to = _ref$props.to,
-        internalTrailingSlash = _ref$props.internalTrailingSlash,
+    var to = _ref.props.to,
         data = _ref.data,
         listeners = _ref.listeners,
-        children = _ref.children;
+        children = _ref.children,
+        parent = _ref.parent;
 
+    var ref, ref1;
     if (!to) {
       return create('span', data, children);
     }
@@ -45,7 +44,7 @@ exports.default = {
       return create('nuxt-link', _extends({}, data, {
         nativeOn: listeners, // nuxt-link doesn't forward events on it's own
         props: {
-          to: internalTrailingSlash ? (0, _index.makeRouterPath)((0, _index.addTrailingSlash)(to)) : (0, _index.makeRouterPath)(to)
+          to: (parent != null ? (ref = parent.$config) != null ? (ref1 = ref.anchorParser) != null ? ref1.addTrailingSlashToInternal : void 0 : void 0 : void 0) ? (0, _index.makeRouterPath)((0, _index.addTrailingSlash)(to)) : (0, _index.makeRouterPath)(to)
         }
       }), children);
     } else {

--- a/smart-link.js
+++ b/smart-link.js
@@ -28,17 +28,14 @@ exports.default = {
   },
 
   // Destructure the props and data we care about
-  // props: { to, internalTrailingSlash }
   render: function render(create, _ref) {
-    var props = _ref.props,
+    var _ref$props = _ref.props,
+        to = _ref$props.to,
+        internalTrailingSlash = _ref$props.internalTrailingSlash,
         data = _ref.data,
         listeners = _ref.listeners,
         children = _ref.children;
 
-    var internalTrailingSlash, to;
-    to = props.to;
-    internalTrailingSlash = props.internalTrailingSlash;
-    console.log('rendering link, to is', to, 'internaltrailingslash is', internalTrailingSlash, 'props are', props);
     if (!to) {
       return create('span', data, children);
     }

--- a/smart-link.js
+++ b/smart-link.js
@@ -22,17 +22,23 @@ var _extends = Object.assign || function (target) {
 exports.default = {
   name: 'SmartLink',
   functional: true,
-  // The URL gets passed here
   props: {
-    to: String
+    to: String, // The URL gets passed here
+    internalTrailingSlash: Boolean // Optionally add trailing slash if is internal link
   },
+
   // Destructure the props and data we care about
+  // props: { to, internalTrailingSlash }
   render: function render(create, _ref) {
-    var to = _ref.props.to,
+    var props = _ref.props,
         data = _ref.data,
         listeners = _ref.listeners,
         children = _ref.children;
 
+    var internalTrailingSlash, to;
+    to = props.to;
+    internalTrailingSlash = props.internalTrailingSlash;
+    console.log('rendering link, to is', to, 'internaltrailingslash is', internalTrailingSlash, 'props are', props);
     if (!to) {
       return create('span', data, children);
     }
@@ -42,7 +48,7 @@ exports.default = {
       return create('nuxt-link', _extends({}, data, {
         nativeOn: listeners, // nuxt-link doesn't forward events on it's own
         props: {
-          to: (0, _index.makeRouterPath)(to)
+          to: internalTrailingSlash ? (0, _index.makeRouterPath)((0, _index.addTrailingSlash)(to)) : (0, _index.makeRouterPath)(to)
         }
       }), children);
     } else {


### PR DESCRIPTION
On HFO all canonical urls have trailing slash, and a bunch of links on the CMS don't have the trailing slash, so a lot of the links in the pages are actually not the canonical version, and thus are not the URLs indexed. This means that we are linking towards pages that are not true end pages in Google’s eyes.

To fix this I propose adding a `internalTrailingSlash` prop to the `smart-link` component, if this prop is true, then the link will automatically add a trailing slash to the URL.